### PR TITLE
specify user-agent for sites that return 403

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -47,7 +47,8 @@ class OpenGraph(dict):
     def fetch(self, url):
         """
         """
-        raw = urllib2.urlopen(url)
+        req = urllib2.Request(url, headers={'User-Agent' : "Mozilla"})
+        raw = urllib2.urlopen(req, timeout=15)
         html = raw.read()
         return self.parser(html)
         


### PR DESCRIPTION
some sites block bots/requests without user-agent headers
